### PR TITLE
Rename hasWarnings field

### DIFF
--- a/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
@@ -100,7 +100,7 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
-    "CaseFieldID": "hasWarnings",
+    "CaseFieldID": "displayWarnings",
     "UserRole": "caseworker-bulkscan",
     "CRUD": "CRUD"
   }

--- a/definitions/bulkscan-exception/data/sheets/CaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseField.json
@@ -123,7 +123,7 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
-    "ID": "hasWarnings",
+    "ID": "displayWarnings",
     "Label": "Has warnings",
     "HintText": "Indicates if there are any warnings to display",
     "FieldType": "YesOrNo",

--- a/definitions/bulkscan-exception/data/sheets/CaseTypeTab.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseTypeTab.json
@@ -8,7 +8,7 @@
     "TabDisplayOrder": 1,
     "CaseFieldID": "ocrDataValidationWarnings",
     "TabFieldDisplayOrder": 1,
-    "TabShowCondition": "hasWarnings=\"Yes\""
+    "TabShowCondition": "displayWarnings=\"Yes\""
   },
   {
     "LiveFrom": "01/01/2018",
@@ -17,9 +17,9 @@
     "TabID": "warnings",
     "TabLabel": "Warnings",
     "TabDisplayOrder": 1,
-    "CaseFieldID": "hasWarnings",
+    "CaseFieldID": "displayWarnings",
     "TabFieldDisplayOrder": 2,
-    "FieldShowCondition": "hasWarnings=\"{NeverShowThisField}\""
+    "FieldShowCondition": "displayWarnings=\"{NeverShowThisField}\""
   },
   {
     "LiveFrom": "01/01/2018",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-757

### Change description ###

Rename `hasWarnings` field to `displayWarnings`, so that the purpose of that field is clearer.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
