### PR TITLE
Add the new "caseReference" field to Bulkscan Exception Record

### DIFF
--- a/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
@@ -72,6 +72,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "UserRole": "caseworker-bulkscan",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "caseHistory",
     "UserRole": "caseworker-bulkscan",
     "CRUD": "CRUD"

--- a/definitions/bulkscan-exception/data/sheets/CaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseField.json
@@ -87,6 +87,15 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "ID": "caseReference",
+    "Label": "Case Reference",
+    "HintText": "Reference number of the new case created from exception record",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "ID": "caseHistory",
     "Label": "Case History",
     "FieldType": "CaseHistoryViewer",

--- a/definitions/bulkscan-exception/data/sheets/CaseTypeTab.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseTypeTab.json
@@ -108,8 +108,18 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "caseReference",
     "TabFieldDisplayOrder": 8
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "attachToCaseReference",
+    "TabFieldDisplayOrder": 9
   },
   {
     "LiveFrom": "01/01/2018",

--- a/definitions/bulkscan-exception/data/sheets/SearchInputFields.json
+++ b/definitions/bulkscan-exception/data/sheets/SearchInputFields.json
@@ -30,15 +30,22 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "Label": "New Case Reference",
+    "DisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   }
 ]

--- a/definitions/bulkscan-exception/data/sheets/SearchResultFields.json
+++ b/definitions/bulkscan-exception/data/sheets/SearchResultFields.json
@@ -23,8 +23,15 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "Label": "New Case Reference",
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 4
+    "DisplayOrder": 5
   }
 ]

--- a/definitions/bulkscan-exception/data/sheets/WorkBasketResultFields.json
+++ b/definitions/bulkscan-exception/data/sheets/WorkBasketResultFields.json
@@ -23,15 +23,22 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "Label": "New Case Reference",
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 4
+    "DisplayOrder": 5
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-785

### Change description ###
Added "caseReference" field to the Bulkscan Exception Record ccd definition.
Attached screenshots to the jira ticket. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
