### PR TITLE
Add "caseReference" field to the Probate Exception Record definition

### DIFF
--- a/definitions/probate/data/sheets/AuthorisationCaseField.json
+++ b/definitions/probate/data/sheets/AuthorisationCaseField.json
@@ -65,6 +65,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "UserRole": "caseworker-probate-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "ocrDataValidationWarnings",
     "UserRole": "caseworker-probate-systemupdate",
     "CRUD": "CRUD"
@@ -149,6 +156,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "UserRole": "caseworker-probate-issuer",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "ocrDataValidationWarnings",
     "UserRole": "caseworker-probate-issuer",
     "CRUD": "CRUD"
@@ -227,6 +241,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
+    "UserRole": "caseworker-probate-caseadmin",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
     "UserRole": "caseworker-probate-caseadmin",
     "CRUD": "CRUD"
   },
@@ -332,6 +353,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
+    "UserRole": "caseworker-probate-bulkscan",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
     "UserRole": "caseworker-probate-bulkscan",
     "CRUD": "CRUD"
   },

--- a/definitions/probate/data/sheets/CaseField.json
+++ b/definitions/probate/data/sheets/CaseField.json
@@ -72,7 +72,16 @@
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "ID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "HintText": "Reference number of the new case created from exception record or existing case to which evidence is attached",
+    "HintText": "The CCD reference number of the case the exception record is attached to",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "ID": "caseReference",
+    "Label": "Case Reference",
+    "HintText": "Reference number of the new case created from exception record",
     "FieldType": "Text",
     "SecurityClassification": "PUBLIC"
   },

--- a/definitions/probate/data/sheets/CaseTypeTab.json
+++ b/definitions/probate/data/sheets/CaseTypeTab.json
@@ -98,8 +98,18 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "caseReference",
     "TabFieldDisplayOrder": 7
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "attachToCaseReference",
+    "TabFieldDisplayOrder": 8
   },
   {
     "LiveFrom": "01/01/2018",

--- a/definitions/probate/data/sheets/SearchInputFields.json
+++ b/definitions/probate/data/sheets/SearchInputFields.json
@@ -30,15 +30,22 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "Label": "New Case Reference",
+    "DisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   }
 ]

--- a/definitions/probate/data/sheets/SearchResultFields.json
+++ b/definitions/probate/data/sheets/SearchResultFields.json
@@ -16,8 +16,15 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "Label": "New Case Reference",
+    "DisplayOrder": 3
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 3
+    "DisplayOrder": 4
   }
 ]

--- a/definitions/probate/data/sheets/WorkBasketResultFields.json
+++ b/definitions/probate/data/sheets/WorkBasketResultFields.json
@@ -23,22 +23,29 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "Label": "New Case Reference",
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 4
+    "DisplayOrder": 5
   },
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "poBox",
     "Label": "POBox",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-785

### Change description ###
Added "caseReference" field to the Probate Exception Record ccd definition.
Attached screenshots to the Jira ticket.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
