### PR TITLE
Add coversheet and form to ScannedDocumentType fixed list (BULKSCAN)

### DIFF
--- a/definitions/bulkscan-exception/data/sheets/FixedLists.json
+++ b/definitions/bulkscan-exception/data/sheets/FixedLists.json
@@ -13,6 +13,18 @@
   },
   {
     "LiveFrom": "01/01/2018",
+    "ID": "ScannedDocumentType",
+    "ListElementCode": "coversheet",
+    "ListElement": "Coversheet"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "ID": "ScannedDocumentType",
+    "ListElementCode": "form",
+    "ListElement": "Form"
+  },
+  {
+    "LiveFrom": "01/01/2018",
     "ID": "ReferenceType",
     "ListElementCode": "ccdCaseReference",
     "ListElement": "CCD Case Reference"

--- a/definitions/bulkscan/data/sheets/FixedLists.json
+++ b/definitions/bulkscan/data/sheets/FixedLists.json
@@ -10,5 +10,17 @@
     "ID": "ScannedDocumentType",
     "ListElementCode": "other",
     "ListElement": "Other"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "ID": "ScannedDocumentType",
+    "ListElementCode": "coversheet",
+    "ListElement": "Coversheet"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "ID": "ScannedDocumentType",
+    "ListElementCode": "form",
+    "ListElement": "Form"
   }
 ]


### PR DESCRIPTION
### Change description ###

Add coversheet and form to ScannedDocumentType fixed list in BULKSCAN-related definitions.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
