### PR TITLE
Add envelopeId field to exception record definition

### DIFF
--- a/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
@@ -110,5 +110,12 @@
     "CaseFieldID": "displayWarnings",
     "UserRole": "caseworker-bulkscan",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "CaseFieldID": "envelopeId",
+    "UserRole": "caseworker-bulkscan",
+    "CRUD": "CRUD"
   }
 ]

--- a/definitions/bulkscan-exception/data/sheets/CaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseField.json
@@ -137,5 +137,14 @@
     "HintText": "Indicates if there are any warnings to display",
     "FieldType": "YesOrNo",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "ID": "envelopeId",
+    "Label": "Envelope ID",
+    "HintText": "ID of the envelope the exception record was created from",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-490

### Change description ###

Add `envelopeId` field to exception record definition. This field will allow for preventing the creation of duplicate exception records. It's for API client use only.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
