### PR TITLE
Update change history version numbers as strings

### DIFF
--- a/definitions/divorce/data/sheets/ChangeHistory.json
+++ b/definitions/divorce/data/sheets/ChangeHistory.json
@@ -1,81 +1,81 @@
 [
   {
-    "Version Number": 0.01,
+    "Version Number": "0.01",
     "Description of Changes": "Create a exception spread sheet",
     "Uses CCD Template": "N/A",
     "LiveFrom": "21/01/2019",
     "Created By": "Ganesh Raja"
   },
   {
-    "Version Number": 0.02,
+    "Version Number": "0.02",
     "Description of Changes": "Added custom event history tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "21/03/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.03,
+    "Version Number": "0.03",
     "Description of Changes": "Added exception record id to WorkBasket results",
     "Uses CCD Template": "N/A",
     "LiveFrom": "03/04/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.04,
+    "Version Number": "0.04",
     "Description of Changes": "Added new document types",
     "LiveFrom": "17/04/2019",
     "Created By": "Rafal Kondratowicz"
   },
   {
-    "Version Number": 0.05,
+    "Version Number": "0.05",
     "Description of Changes": "CaseEvent tab cleanup (probate content was added to the top right side of the sheet)",
     "LiveFrom": "09/05/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.06,
+    "Version Number": "0.06",
     "Description of Changes": "Added new role to Authorisation tabs",
     "Uses CCD Template": "N/A",
     "LiveFrom": "30/05/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.07,
+    "Version Number": "0.07",
     "Description of Changes": "Added PO Box field to WorkBasketResults tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "06/06/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.08,
+    "Version Number": "0.08",
     "Description of Changes": "Updated ScannedDocument complex type to include deliveryDate field",
     "Uses CCD Template": "N/A",
     "LiveFrom": "11/06/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.09,
+    "Version Number": "0.09",
     "Description of Changes": "Added AuthorisationComplexType tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "19/06/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.1,
+    "Version Number": "0.10",
     "Description of Changes": "Add JourneyClassification to SearchInputFields and WorkBasketResultFields",
     "Uses CCD Template": "N/A",
     "LiveFrom": "01/08/2019",
     "Created By": "Donatas Martinkus"
   },
   {
-    "Version Number": 0.11,
+    "Version Number": "0.11",
     "Description of Changes": "Add Warnings tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "05/09/2019",
     "Created By": "Leszek Gonczar"
   },
   {
-    "Version Number": 0.12,
+    "Version Number": "0.12",
     "Description of Changes": "Add formtype field",
     "Uses CCD Template": "N/A",
     "LiveFrom": "12/09/2019",

--- a/definitions/finrem/data/sheets/ChangeHistory.json
+++ b/definitions/finrem/data/sheets/ChangeHistory.json
@@ -1,76 +1,76 @@
 [
   {
-    "Version Number": 0.01,
+    "Version Number": "0.01",
     "Description of Changes": "Create a Financial Remedy exception record spread sheet",
     "Uses CCD Template": "N/A",
     "LiveFrom": "10/04/2019",
     "Created By": "Chandra Korivi"
   },
   {
-    "Version Number": 0.02,
+    "Version Number": "0.02",
     "Description of Changes": "Removed duplicate values from FixedLists tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "29/04/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.03,
+    "Version Number": "0.03",
     "Description of Changes": "Cleanup CaseEvent tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "08/05/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.04,
+    "Version Number": "0.04",
     "Description of Changes": "Add new role to Authorisation tabs",
     "Uses CCD Template": "N/A",
     "LiveFrom": "30/05/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.05,
+    "Version Number": "0.05",
     "Description of Changes": "Add PO Box to WorkBasketResults tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "06/06/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.06,
+    "Version Number": "0.06",
     "Description of Changes": "Added deliveryDate field to ScannedDocument ComplexType",
     "Uses CCD Template": "N/A",
     "LiveFrom": "11/06/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.07,
+    "Version Number": "0.07",
     "Description of Changes": "Added AuthorisationComplexType tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "19/06/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.08,
+    "Version Number": "0.08",
     "Description of Changes": "Add JourneyClassification to SearchInputFields and WorkBasketResultFields",
     "Uses CCD Template": "N/A",
     "LiveFrom": "01/08/2019",
     "Created By": "Donatas Martinkus"
   },
   {
-    "Version Number": 0.09,
+    "Version Number": "0.09",
     "Description of Changes": "Add Warnings tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "05/09/2019",
     "Created By": "Leszek Gonczar"
   },
   {
-    "Version Number": 0.1,
+    "Version Number": "0.10",
     "Description of Changes": "Add Formtype to Ocr tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "12/09/2019",
     "Created By": "Mustafa Dayican"
   },
   {
-    "Version Number": 0.11,
+    "Version Number": "0.11",
     "Description of Changes": "Add envelopeId field",
     "Uses CCD Template": "N/A",
     "LiveFrom": "23/09/2019",

--- a/definitions/probate/data/sheets/ChangeHistory.json
+++ b/definitions/probate/data/sheets/ChangeHistory.json
@@ -1,87 +1,90 @@
 [
   {
-    "Version Number": 0.01,
+    "Version Number": "0.01",
     "Description of Changes": "Initial version of probate exception record with the new probate roles.",
     "Uses CCD Template": "N/A",
     "LiveFrom": "25/03/2019",
     "Created By": "Rabab Samir Rabab"
   },
   {
-    "Version Number": 0.02,
+    "Version Number": "0.02",
     "Description of Changes": "Added custom Event history tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "26/03/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.03,
+    "Version Number": "0.03",
     "Description of Changes": "Added exception record id to WorkBasket results",
     "Uses CCD Template": "N/A",
     "LiveFrom": "03/04/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.04,
-    "Description of Changes": "Added new document types"
+    "Version Number": "0.04",
+    "Description of Changes": "Added new document types",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "17/05/2019",
+    "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.05,
+    "Version Number": "0.05",
     "Description of Changes": "Added new role to Authorisation tabs",
     "Uses CCD Template": "N/A",
     "LiveFrom": "30/05/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.06,
+    "Version Number": "0.06",
     "Description of Changes": "Added po box field to WorkBasketResults tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "06/06/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.07,
+    "Version Number": "0.07",
     "Description of Changes": "Added deliveryDate field to ScannedDocument complex type",
     "Uses CCD Template": "N/A",
     "LiveFrom": "11/06/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.08,
+    "Version Number": "0.08",
     "Description of Changes": "Added AuthorisationComplexType tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "19/06/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.09,
+    "Version Number": "0.09",
     "Description of Changes": "Add JourneyClassification to SearchInputFields and WorkBasketResultFields",
     "Uses CCD Template": "N/A",
     "LiveFrom": "01/08/2019",
     "Created By": "Donatas Martinkus"
   },
   {
-    "Version Number": 0.1,
+    "Version Number": "0.10",
     "Description of Changes": "Add Warnings tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "05/09/2019",
     "Created By": "Leszek Gonczar"
   },
   {
-    "Version Number": 0.11,
+    "Version Number": "0.11",
     "Description of Changes": "Add Formtype field to OCR tab",
     "Uses CCD Template": "N/A",
     "LiveFrom": "12/09/2019",
     "Created By": "Mustafa Dayican"
   },
   {
-    "Version Number": 0.12,
+    "Version Number": "0.12",
     "Description of Changes": "Add caseReference field to see the new case id created from the Exception Record",
     "Uses CCD Template": "N/A",
     "LiveFrom": "16/09/2019",
     "Created By": "Aliveni Choppa"
   },
   {
-    "Version Number": 0.13,
+    "Version Number": "0.13",
     "Description of Changes": "Add envelopeId field",
     "Uses CCD Template": "N/A",
     "LiveFrom": "23/09/2019",


### PR DESCRIPTION
### Change description ###
At the moment, the version numbers format in the ChnageHistory sheet is `Number`. This format is rounding/wrapping the decimals after the period. (for eg: `0.10` becomes `0.1`) 
So I've changed the format to string.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
