### PR TITLE
Add awaitingDCNProcessing field to bulkscan exception record

### DIFF
--- a/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
@@ -121,7 +121,7 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
-    "CaseFieldID": "awaitingPaymentDcnsProcessing",
+    "CaseFieldID": "awaitingPaymentDCNProcessing",
     "UserRole": "caseworker-bulkscan",
     "CRUD": "CRUD"
   }

--- a/definitions/bulkscan-exception/data/sheets/CaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseField.json
@@ -150,8 +150,8 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
-    "ID": "awaitingPaymentDcnsProcessing",
-    "Label": "Awaiting Payment DCNs processing",
+    "ID": "awaitingPaymentDCNProcessing",
+    "Label": "Awaiting Payment DCN processing",
     "HintText": "Indicates if the payment document control numbers are being processed",
     "FieldType": "YesOrNo",
     "SecurityClassification": "PUBLIC"

--- a/definitions/bulkscan-exception/data/sheets/ChangeHistory.json
+++ b/definitions/bulkscan-exception/data/sheets/ChangeHistory.json
@@ -155,7 +155,7 @@
   },
   {
     "Version Number": "0.23",
-    "Description of Changes": "Add awaitingPaymentDcnsProcessing field to ExceptionRecord",
+    "Description of Changes": "Add awaitingPaymentDCNProcessing field to ExceptionRecord",
     "Uses CCD Template": "N/A",
     "LiveFrom": "27/09/2019",
     "Created By": "Aliveni Choppa"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-814

### Change description ###
Added awaitingDCNProcessing field.
Uploaded in demo environment. This field is not shown on the CCD UI, only used by backend service


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
