### PR TITLE
Add awaitingDCNProcessing field to DIVORCE exception record

### DIFF
--- a/definitions/divorce/data/sheets/AuthorisationCaseField.json
+++ b/definitions/divorce/data/sheets/AuthorisationCaseField.json
@@ -282,7 +282,7 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
-    "CaseFieldID": "awaitingPaymentDcnsProcessing",
+    "CaseFieldID": "awaitingPaymentDCNProcessing",
     "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "CRUD"
   }

--- a/definitions/divorce/data/sheets/CaseField.json
+++ b/definitions/divorce/data/sheets/CaseField.json
@@ -122,8 +122,8 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
-    "ID": "awaitingPaymentDcnsProcessing",
-    "Label": "Awaiting Payment DCNs processing",
+    "ID": "awaitingPaymentDCNProcessing",
+    "Label": "Awaiting Payment DCN processing",
     "HintText": "Indicates if the payment document control numbers are being processed",
     "FieldType": "YesOrNo",
     "SecurityClassification": "PUBLIC"

--- a/definitions/divorce/data/sheets/ChangeHistory.json
+++ b/definitions/divorce/data/sheets/ChangeHistory.json
@@ -90,7 +90,7 @@
   },
   {
     "Version Number": "0.14",
-    "Description of Changes": "Add awaitingPaymentDcnsProcessing field to ExceptionRecord",
+    "Description of Changes": "Add awaitingPaymentDCNProcessing field to ExceptionRecord",
     "Uses CCD Template": "N/A",
     "LiveFrom": "27/09/2019",
     "Created By": "Aliveni Choppa"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-814

### Change description ###
Added awaitingDCNProcessing field.
This field is not shown on the CCD UI, only used by backend service.
Uploaded in demo environment for testing.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
