### PR TITLE
BPS-784 Add containsPayments field to SSCS Exception record

### DIFF
--- a/definitions/sscs/data/sheets/AuthorisationCaseField.json
+++ b/definitions/sscs/data/sheets/AuthorisationCaseField.json
@@ -98,6 +98,13 @@
     "CRUD": "CRUD"
   },
   {
+    "LiveFrom": "07/10/2019",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
+    "UserRole": "caseworker-sscs",
+    "CRUD": "CRUD"
+  },
+  {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
@@ -213,6 +220,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "caseHistory",
+    "UserRole": "caseworker-sscs-clerk",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "07/10/2019",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
     "UserRole": "caseworker-sscs-clerk",
     "CRUD": "CRUD"
   },
@@ -346,6 +360,13 @@
     "LiveFrom": "27/09/2019",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "awaitingPaymentDCNProcessing",
+    "UserRole": "caseworker-sscs-bulkscan",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "07/10/2019",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
     "UserRole": "caseworker-sscs-bulkscan",
     "CRUD": "CRUD"
   }

--- a/definitions/sscs/data/sheets/CaseEventToFields.json
+++ b/definitions/sscs/data/sheets/CaseEventToFields.json
@@ -101,6 +101,17 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseEventID": "createException",
+    "CaseFieldID": "containsPayments",
+    "PageFieldDisplayOrder": 10,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondance",
+    "PageColumnNumber": 1
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
     "CaseFieldID": "attachToCaseReference",
     "PageFieldDisplayOrder": 1,

--- a/definitions/sscs/data/sheets/CaseField.json
+++ b/definitions/sscs/data/sheets/CaseField.json
@@ -152,5 +152,14 @@
     "HintText": "Indicates if the payment document control numbers are being processed",
     "FieldType": "YesOrNo",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "ID": "containsPayments",
+    "Label": "Contains Payments",
+    "HintText": "Indicates if the Exception record contains payments",
+    "FieldType": "YesOrNo",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/sscs/data/sheets/CaseTypeTab.json
+++ b/definitions/sscs/data/sheets/CaseTypeTab.json
@@ -115,6 +115,16 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "containsPayments",
+    "TabFieldDisplayOrder": 9
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "Channel": "CaseWorker",
     "TabID": "documentation",
     "TabLabel": "Documentation",
     "TabDisplayOrder": 4,

--- a/definitions/sscs/data/sheets/ChangeHistory.json
+++ b/definitions/sscs/data/sheets/ChangeHistory.json
@@ -117,5 +117,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "27/09/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "1.0.20",
+    "Description of Changes": "Add containsPayments field to ExceptionRecord",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "07/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/sscs/data/sheets/SearchInputFields.json
+++ b/definitions/sscs/data/sheets/SearchInputFields.json
@@ -54,5 +54,12 @@
     "CaseFieldID": "labelJourneyClassification",
     "Label": "**Journey Classification**: *new_application*, *supplementary_evidence* or *exception*.",
     "DisplayOrder": 8
+  },
+  {
+    "LiveFrom": "22/08/2019",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
+    "Label": "Contains Payments",
+    "DisplayOrder": 9
   }
 ]

--- a/definitions/sscs/data/sheets/WorkBasketInputFields.json
+++ b/definitions/sscs/data/sheets/WorkBasketInputFields.json
@@ -1,1 +1,9 @@
-[]
+[
+  {
+    "LiveFrom": "22/08/2019",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
+    "Label": "Contains Payments",
+    "DisplayOrder": 1
+  }
+]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-784

### Change description ###
Add `containsPayments` field to SSCS ExceptionRecord definition.
Add filter on `containsPayments` field in Search input fields and Workbasket input fields.
Uploaded the definition on demo and attached screenshots to the ticket.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
