### PR TITLE
Add containsPayments field to PROBATE Exception record

### DIFF
--- a/definitions/probate/data/sheets/AuthorisationCaseField.json
+++ b/definitions/probate/data/sheets/AuthorisationCaseField.json
@@ -100,6 +100,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
+    "UserRole": "caseworker-probate-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
     "UserRole": "caseworker-probate-issuer",
     "CRUD": "CRUD"
@@ -191,6 +198,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
+    "UserRole": "caseworker-probate-issuer",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
     "UserRole": "caseworker-probate-caseadmin",
     "CRUD": "CRUD"
@@ -278,6 +292,13 @@
     "CaseFieldID": "formType",
     "UserRole": "caseworker-probate-caseadmin",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
+    "UserRole": "caseworker-probate-caseadmin",
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2018",
@@ -397,6 +418,13 @@
     "CaseFieldID": "formType",
     "UserRole": "caseworker-probate-bulkscan",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
+    "UserRole": "caseworker-probate-bulkscan",
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2018",

--- a/definitions/probate/data/sheets/CaseEventToFields.json
+++ b/definitions/probate/data/sheets/CaseEventToFields.json
@@ -101,6 +101,17 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseEventID": "createException",
+    "CaseFieldID": "containsPayments",
+    "PageFieldDisplayOrder": 10,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondence",
+    "PageDisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
     "CaseFieldID": "attachToCaseReference",
     "PageFieldDisplayOrder": 1,

--- a/definitions/probate/data/sheets/CaseField.json
+++ b/definitions/probate/data/sheets/CaseField.json
@@ -136,5 +136,14 @@
     "HintText": "Indicates if the payment document control numbers are being processed",
     "FieldType": "YesOrNo",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "ID": "containsPayments",
+    "Label": "Contains Payments",
+    "HintText": "Indicates if the Exception record contains payments",
+    "FieldType": "YesOrNo",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/probate/data/sheets/CaseTypeTab.json
+++ b/definitions/probate/data/sheets/CaseTypeTab.json
@@ -115,6 +115,16 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "containsPayments",
+    "TabFieldDisplayOrder": 9
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "Channel": "CaseWorker",
     "TabID": "documentation",
     "TabLabel": "Documentation",
     "TabDisplayOrder": 4,

--- a/definitions/probate/data/sheets/ChangeHistory.json
+++ b/definitions/probate/data/sheets/ChangeHistory.json
@@ -110,5 +110,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "27/09/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "0.17",
+    "Description of Changes": "Add containsPayments field to ExceptionRecord",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "07/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/probate/data/sheets/SearchInputFields.json
+++ b/definitions/probate/data/sheets/SearchInputFields.json
@@ -54,5 +54,12 @@
     "CaseFieldID": "formType",
     "Label": "Form Type",
     "DisplayOrder": 8
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
+    "Label": "Contains Payments",
+    "DisplayOrder": 9
   }
 ]

--- a/definitions/probate/data/sheets/WorkBasketInputFields.json
+++ b/definitions/probate/data/sheets/WorkBasketInputFields.json
@@ -5,5 +5,12 @@
     "CaseFieldID": "formType",
     "Label": "Form Type",
     "DisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2019",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "containsPayments",
+    "Label": "Contains Payments",
+    "DisplayOrder": 2
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-784

### Change description ###
Add `containsPayments` field to Probate ExceptionRecord definition.
Add filter on `containsPayments` field in Search input fields and Workbasket input fields.
Uploaded the definition on demo and attached screenshots to the ticket.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
