### PR TITLE
Update caseworker roles to have only read access for containsPayments field

### DIFF
--- a/definitions/cmc/data/sheets/AuthorisationCaseField.json
+++ b/definitions/cmc/data/sheets/AuthorisationCaseField.json
@@ -228,7 +228,7 @@
     "CaseTypeID": "CMC_ExceptionRecord",
     "CaseFieldID": "containsPayments",
     "UserRole": "caseworker-cmc-bulkscan",
-    "CRUD": "CRUD"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2018",
@@ -340,7 +340,7 @@
     "CaseTypeID": "CMC_ExceptionRecord",
     "CaseFieldID": "containsPayments",
     "UserRole": "caseworker-cmc",
-    "CRUD": "CRUD"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2018",

--- a/definitions/sscs/data/sheets/AuthorisationCaseField.json
+++ b/definitions/sscs/data/sheets/AuthorisationCaseField.json
@@ -228,7 +228,7 @@
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "containsPayments",
     "UserRole": "caseworker-sscs-clerk",
-    "CRUD": "CRUD"
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2018",
@@ -368,6 +368,6 @@
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "containsPayments",
     "UserRole": "caseworker-sscs-bulkscan",
-    "CRUD": "CRUD"
+    "CRUD": "R"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-784

### Change description ###
The caseworker roles should have read-only access for `containsPayments` field. The`systemupdate` role should have `CRUD`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
