### PR TITLE
Bug - Fix authorisation of awaitingPaymentDCNProcessing field for SSCS

### DIFF
--- a/definitions/sscs/data/sheets/AuthorisationCaseField.json
+++ b/definitions/sscs/data/sheets/AuthorisationCaseField.json
@@ -98,6 +98,13 @@
     "CRUD": "CRUD"
   },
   {
+    "LiveFrom": "27/09/2019",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "awaitingPaymentDCNProcessing",
+    "UserRole": "caseworker-sscs",
+    "CRUD": "CRUD"
+  },
+  {
     "LiveFrom": "07/10/2019",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "containsPayments",
@@ -353,13 +360,6 @@
     "LiveFrom": "22/08/2019",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "formType",
-    "UserRole": "caseworker-sscs-bulkscan",
-    "CRUD": "CRUD"
-  },
-  {
-    "LiveFrom": "27/09/2019",
-    "CaseTypeID": "SSCS_ExceptionRecord",
-    "CaseFieldID": "awaitingPaymentDCNProcessing",
     "UserRole": "caseworker-sscs-bulkscan",
     "CRUD": "CRUD"
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-814


### Change description ###
`awaitingPaymentDCNProcessing` field should have `Crud` access for systemupdate role only.
For sscs, it should be `casworker-sscs` instead of `caseworker-bulkscan-sscs`.

Applied definition changes in the demo and tested.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
