### PR TITLE
Remove containsPayments field from `createCase` and `createException` events

### DIFF
--- a/definitions/bulkscan-exception/data/sheets/CaseEventToFields.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseEventToFields.json
@@ -79,17 +79,6 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
-    "CaseEventID": "createNewCase",
-    "CaseFieldID": "containsPayments",
-    "PageFieldDisplayOrder": 3,
-    "DisplayContext": "OPTIONAL",
-    "PageID": 1,
-    "PageLabel": "Corespondance",
-    "PageColumnNumber": 1
-  },
-  {
-    "LiveFrom": "01/01/2018",
-    "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseEventID": "updateManually",
     "CaseFieldID": "scannedDocuments",
     "PageFieldDisplayOrder": 1,

--- a/definitions/bulkscan-exception/data/sheets/ChangeHistory.json
+++ b/definitions/bulkscan-exception/data/sheets/ChangeHistory.json
@@ -187,5 +187,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "13/10/2019",
     "Created By": "Rafal Kondratowicz"
+  },
+  {
+    "Version Number": "0.28",
+    "Description of Changes": "Remove containsPayments field from createCase event ",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "15/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/cmc/data/sheets/CaseEventToFields.json
+++ b/definitions/cmc/data/sheets/CaseEventToFields.json
@@ -88,17 +88,6 @@
     "PageDisplayOrder": 1
   },
   {
-    "LiveFrom": "01/01/2018",
-    "CaseTypeID": "CMC_ExceptionRecord",
-    "CaseEventID": "createException",
-    "CaseFieldID": "containsPayments",
-    "PageFieldDisplayOrder": 9,
-    "DisplayContext": "OPTIONAL",
-    "PageID": 1,
-    "PageLabel": "Corespondence",
-    "PageDisplayOrder": 1
-  },
-  {
     "LiveFrom": "02/01/2018",
     "CaseTypeID": "CMC_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",

--- a/definitions/cmc/data/sheets/ChangeHistory.json
+++ b/definitions/cmc/data/sheets/ChangeHistory.json
@@ -128,5 +128,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "09/10/2019",
     "Created By": "Leszek Gonczar"
+  },
+  {
+    "Version Number": "0.2.17",
+    "Description of Changes": "Remove containsPayments field from createCase event ",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "15/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/divorce/data/sheets/CaseEventToFields.json
+++ b/definitions/divorce/data/sheets/CaseEventToFields.json
@@ -101,17 +101,6 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
-    "CaseEventID": "createException",
-    "CaseFieldID": "containsPayments",
-    "PageFieldDisplayOrder": 10,
-    "DisplayContext": "OPTIONAL",
-    "PageID": 1,
-    "PageLabel": "Corespondence",
-    "PageDisplayOrder": 1
-  },
-  {
-    "LiveFrom": "01/01/2018",
-    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
     "CaseFieldID": "attachToCaseReference",
     "PageFieldDisplayOrder": 1,

--- a/definitions/divorce/data/sheets/ChangeHistory.json
+++ b/definitions/divorce/data/sheets/ChangeHistory.json
@@ -108,5 +108,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "09/10/2019",
     "Created By": "Leszek Gonczar"
+  },
+  {
+    "Version Number": "0.17",
+    "Description of Changes": "Remove containsPayments field from createCase event ",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "15/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/finrem/data/sheets/CaseEventToFields.json
+++ b/definitions/finrem/data/sheets/CaseEventToFields.json
@@ -101,17 +101,6 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "FINREM_ExceptionRecord",
-    "CaseEventID": "createException",
-    "CaseFieldID": "containsPayments",
-    "PageFieldDisplayOrder": 10,
-    "DisplayContext": "OPTIONAL",
-    "PageID": 1,
-    "PageLabel": "Corespondence",
-    "PageDisplayOrder": 1
-  },
-  {
-    "LiveFrom": "01/01/2018",
-    "CaseTypeID": "FINREM_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
     "CaseFieldID": "attachToCaseReference",
     "PageFieldDisplayOrder": 1,

--- a/definitions/finrem/data/sheets/ChangeHistory.json
+++ b/definitions/finrem/data/sheets/ChangeHistory.json
@@ -96,5 +96,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "09/10/2019",
     "Created By": "Leszek Gonczar"
+  },
+  {
+    "Version Number": "0.15",
+    "Description of Changes": "Remove containsPayments field from createCase event ",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "15/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/probate/data/sheets/CaseEventToFields.json
+++ b/definitions/probate/data/sheets/CaseEventToFields.json
@@ -101,17 +101,6 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
-    "CaseEventID": "createException",
-    "CaseFieldID": "containsPayments",
-    "PageFieldDisplayOrder": 10,
-    "DisplayContext": "OPTIONAL",
-    "PageID": 1,
-    "PageLabel": "Corespondence",
-    "PageDisplayOrder": 1
-  },
-  {
-    "LiveFrom": "01/01/2018",
-    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
     "CaseFieldID": "attachToCaseReference",
     "PageFieldDisplayOrder": 1,

--- a/definitions/probate/data/sheets/ChangeHistory.json
+++ b/definitions/probate/data/sheets/ChangeHistory.json
@@ -124,5 +124,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "09/10/2019",
     "Created By": "Leszek Gonczar"
+  },
+  {
+    "Version Number": "0.19",
+    "Description of Changes": "Remove containsPayments field from createCase event ",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "15/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/sscs/data/sheets/CaseEventToFields.json
+++ b/definitions/sscs/data/sheets/CaseEventToFields.json
@@ -101,17 +101,6 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
-    "CaseEventID": "createException",
-    "CaseFieldID": "containsPayments",
-    "PageFieldDisplayOrder": 10,
-    "DisplayContext": "OPTIONAL",
-    "PageID": 1,
-    "PageLabel": "Corespondance",
-    "PageColumnNumber": 1
-  },
-  {
-    "LiveFrom": "01/01/2018",
-    "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
     "CaseFieldID": "attachToCaseReference",
     "PageFieldDisplayOrder": 1,

--- a/definitions/sscs/data/sheets/ChangeHistory.json
+++ b/definitions/sscs/data/sheets/ChangeHistory.json
@@ -131,5 +131,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "09/10/2019",
     "Created By": "Leszek Gonczar"
+  },
+  {
+    "Version Number": "1.0.22",
+    "Description of Changes": "Remove containsPayments field from createCase event ",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "15/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-784

### Change description ###
`containsPayments` field need to be removed from `CaseEventToFields` in all exception record definitions. 
Applied this change for Bulkscan-exception, probate, divorce, finrem, cmc and sscs exception record definitions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
