### PR TITLE
Remove authorization for completeAwaitingPaymentDCNProcessing event

### DIFF
--- a/definitions/sscs/data/sheets/AuthorisationCaseEvent.json
+++ b/definitions/sscs/data/sheets/AuthorisationCaseEvent.json
@@ -37,13 +37,6 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
-    "CaseEventID": "completeAwaitingPaymentDCNProcessing",
-    "UserRole": "caseworker-sscs",
-    "CRUD": "CRUD"
-  },
-  {
-    "LiveFrom": "01/01/2018",
-    "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseEventID": "createException",
     "UserRole": "caseworker-sscs-clerk",
     "CRUD": "CRUD"

--- a/definitions/sscs/data/sheets/ChangeHistory.json
+++ b/definitions/sscs/data/sheets/ChangeHistory.json
@@ -138,5 +138,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "15/10/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "1.0.23",
+    "Description of Changes": "Remove authorization for completeAwaitingPaymentDCNProcessing event",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "16/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]


### PR DESCRIPTION
### Change description ###
Removed authorization entries for completeAwaitingPaymentDCNProcessing event in SSCS exception record definition.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
