### PR TITLE
Add envelope case reference to PROBATE exception record

### DIFF
--- a/definitions/probate/data/sheets/AuthorisationCaseField.json
+++ b/definitions/probate/data/sheets/AuthorisationCaseField.json
@@ -107,6 +107,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "UserRole": "caseworker-probate-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
     "UserRole": "caseworker-probate-issuer",
     "CRUD": "CRUD"
@@ -205,6 +212,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "UserRole": "caseworker-probate-issuer",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
     "UserRole": "caseworker-probate-caseadmin",
     "CRUD": "CRUD"
@@ -297,6 +311,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "containsPayments",
+    "UserRole": "caseworker-probate-caseadmin",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
     "UserRole": "caseworker-probate-caseadmin",
     "CRUD": "R"
   },
@@ -451,6 +472,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "paymentHistory",
+    "UserRole": "caseworker-probate-bulkscan",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
     "UserRole": "caseworker-probate-bulkscan",
     "CRUD": "R"
   }

--- a/definitions/probate/data/sheets/CaseEventToFields.json
+++ b/definitions/probate/data/sheets/CaseEventToFields.json
@@ -101,6 +101,17 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseEventID": "createException",
+    "CaseFieldID": "envelopeCaseReference",
+    "PageFieldDisplayOrder": 10,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondance",
+    "PageColumnNumber": 1
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
     "CaseFieldID": "attachToCaseReference",
     "PageFieldDisplayOrder": 1,

--- a/definitions/probate/data/sheets/CaseField.json
+++ b/definitions/probate/data/sheets/CaseField.json
@@ -153,5 +153,14 @@
     "Label": "Payment history",
     "FieldType": "CasePaymentHistoryViewer",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "ID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "HintText": "The case reference number received in the envelope",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/probate/data/sheets/CaseTypeTab.json
+++ b/definitions/probate/data/sheets/CaseTypeTab.json
@@ -108,7 +108,7 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "envelopeCaseReference",
     "TabFieldDisplayOrder": 8
   },
   {
@@ -118,8 +118,18 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "containsPayments",
+    "CaseFieldID": "attachToCaseReference",
     "TabFieldDisplayOrder": 9
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "containsPayments",
+    "TabFieldDisplayOrder": 10
   },
   {
     "LiveFrom": "01/01/2018",

--- a/definitions/probate/data/sheets/ChangeHistory.json
+++ b/definitions/probate/data/sheets/ChangeHistory.json
@@ -145,5 +145,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "16/10/2019",
     "Created By": "Rafal Kondratowicz"
+  },
+  {
+    "Version Number": "0.22",
+    "Description of Changes": "Add envelope case reference received for supplementary evidence",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "25/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/probate/data/sheets/SearchResultFields.json
+++ b/definitions/probate/data/sheets/SearchResultFields.json
@@ -23,15 +23,22 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 4
+    "DisplayOrder": 5
   },
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "formType",
     "Label": "Form Type",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   }
 ]

--- a/definitions/probate/data/sheets/WorkBasketResultFields.json
+++ b/definitions/probate/data/sheets/WorkBasketResultFields.json
@@ -30,29 +30,36 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "DisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "poBox",
     "Label": "POBox",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 7
+    "DisplayOrder": 8
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "formType",
     "Label": "Form Type",
-    "DisplayOrder": 8
+    "DisplayOrder": 9
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-831

### Change description ###
- Added new field `envelopeCaseReference` to Exception Record case fields, which will be displayed on Exception Record.
- Added `envelopeCaseReference` to Workbasket results and Search Results.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
