### PR TITLE
Add envelope case reference to BULKSCAN exception record

### DIFF
--- a/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/AuthorisationCaseField.json
@@ -138,5 +138,12 @@
     "CaseFieldID": "paymentHistory",
     "UserRole": "caseworker-bulkscan",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "UserRole": "caseworker-bulkscan",
+    "CRUD": "CRUD"
   }
 ]

--- a/definitions/bulkscan-exception/data/sheets/CaseField.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseField.json
@@ -172,5 +172,14 @@
     "Label": "Payment history",
     "FieldType": "CasePaymentHistoryViewer",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "ID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "HintText": "The case reference number received in the envelope",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/bulkscan-exception/data/sheets/CaseTypeTab.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseTypeTab.json
@@ -118,7 +118,7 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "envelopeCaseReference",
     "TabFieldDisplayOrder": 9
   },
   {
@@ -128,8 +128,18 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "containsPayments",
+    "CaseFieldID": "attachToCaseReference",
     "TabFieldDisplayOrder": 10
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "containsPayments",
+    "TabFieldDisplayOrder": 11
   },
   {
     "LiveFrom": "01/01/2018",

--- a/definitions/bulkscan-exception/data/sheets/ChangeHistory.json
+++ b/definitions/bulkscan-exception/data/sheets/ChangeHistory.json
@@ -201,5 +201,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "15/10/2019",
     "Created By": "Rafal Kondratowicz"
+  },
+  {
+    "Version Number": "0.30",
+    "Description of Changes": "Add envelope case reference received for supplementary evidence",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "29/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/bulkscan-exception/data/sheets/SearchResultFields.json
+++ b/definitions/bulkscan-exception/data/sheets/SearchResultFields.json
@@ -30,15 +30,22 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "DisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "formType",
     "Label": "Form Type",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   }
 ]

--- a/definitions/bulkscan-exception/data/sheets/WorkBasketResultFields.json
+++ b/definitions/bulkscan-exception/data/sheets/WorkBasketResultFields.json
@@ -30,22 +30,29 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "DisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "CaseFieldID": "formType",
     "Label": "Form Type",
-    "DisplayOrder": 7
+    "DisplayOrder": 8
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-831

### Change description ###
- Added new field `envelopeCaseReference` to Exception Record case fields, which will be displayed on Exception Record.
- Added `envelopeCaseReference` to Workbasket results and Search Results.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
