### PR TITLE
Add envelope case reference to DIVORCE exception record

### DIFF
--- a/definitions/divorce/data/sheets/AuthorisationCaseField.json
+++ b/definitions/divorce/data/sheets/AuthorisationCaseField.json
@@ -100,6 +100,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
     "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "CRUD"
@@ -205,6 +212,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "UserRole": "caseworker-divorce-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
     "UserRole": "caseworker-divorce-bulkscan",
     "CRUD": "CRUD"
@@ -297,6 +311,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "containsPayments",
+    "UserRole": "caseworker-divorce-bulkscan",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
     "UserRole": "caseworker-divorce-bulkscan",
     "CRUD": "R"
   },

--- a/definitions/divorce/data/sheets/CaseEventToFields.json
+++ b/definitions/divorce/data/sheets/CaseEventToFields.json
@@ -101,6 +101,17 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseEventID": "createException",
+    "CaseFieldID": "envelopeCaseReference",
+    "PageFieldDisplayOrder": 10,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondance",
+    "PageColumnNumber": 1
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
     "CaseFieldID": "attachToCaseReference",
     "PageFieldDisplayOrder": 1,

--- a/definitions/divorce/data/sheets/CaseField.json
+++ b/definitions/divorce/data/sheets/CaseField.json
@@ -136,5 +136,14 @@
     "HintText": "Indicates if the Exception record contains payments",
     "FieldType": "YesOrNo",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "ID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "HintText": "The case reference number received in the envelope",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/divorce/data/sheets/CaseTypeTab.json
+++ b/definitions/divorce/data/sheets/CaseTypeTab.json
@@ -98,7 +98,7 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "envelopeCaseReference",
     "TabFieldDisplayOrder": 7
   },
   {
@@ -108,8 +108,18 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "containsPayments",
+    "CaseFieldID": "attachToCaseReference",
     "TabFieldDisplayOrder": 8
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "containsPayments",
+    "TabFieldDisplayOrder": 9
   },
   {
     "LiveFrom": "01/01/2017",

--- a/definitions/divorce/data/sheets/ChangeHistory.json
+++ b/definitions/divorce/data/sheets/ChangeHistory.json
@@ -115,5 +115,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "15/10/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "0.18",
+    "Description of Changes": "Add envelope case reference received for supplementary evidence",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "29/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/divorce/data/sheets/SearchResultFields.json
+++ b/definitions/divorce/data/sheets/SearchResultFields.json
@@ -16,8 +16,15 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "DisplayOrder": 3
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 3
+    "DisplayOrder": 4
   }
 ]

--- a/definitions/divorce/data/sheets/WorkBasketResultFields.json
+++ b/definitions/divorce/data/sheets/WorkBasketResultFields.json
@@ -23,22 +23,29 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 4
+    "DisplayOrder": 5
   },
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "poBox",
     "Label": "PO Box",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-831

### Change description ###
- Added new field `envelopeCaseReference` to Exception Record case fields, which will be displayed on Exception Record.
- Added `envelopeCaseReference` to Workbasket results and Search Results.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
