### PR TITLE
Add envelope case reference to CMC exception record

### DIFF
--- a/definitions/cmc/data/sheets/AuthorisationCaseField.json
+++ b/definitions/cmc/data/sheets/AuthorisationCaseField.json
@@ -121,6 +121,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "CMC_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "UserRole": "caseworker-cmc-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
     "UserRole": "caseworker-cmc-bulkscan",
     "CRUD": "CRUD"
@@ -233,6 +240,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "CMC_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "UserRole": "caseworker-cmc-bulkscan",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
     "UserRole": "caseworker-cmc",
     "CRUD": "CRUD"
@@ -339,6 +353,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "CMC_ExceptionRecord",
     "CaseFieldID": "containsPayments",
+    "UserRole": "caseworker-cmc",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
     "UserRole": "caseworker-cmc",
     "CRUD": "R"
   },

--- a/definitions/cmc/data/sheets/CaseEventToFields.json
+++ b/definitions/cmc/data/sheets/CaseEventToFields.json
@@ -88,6 +88,17 @@
     "PageDisplayOrder": 1
   },
   {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "CaseEventID": "createException",
+    "CaseFieldID": "envelopeCaseReference",
+    "PageFieldDisplayOrder": 9,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondence",
+    "PageDisplayOrder": 1
+  },
+  {
     "LiveFrom": "02/01/2018",
     "CaseTypeID": "CMC_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",

--- a/definitions/cmc/data/sheets/CaseField.json
+++ b/definitions/cmc/data/sheets/CaseField.json
@@ -155,5 +155,14 @@
     "HintText": "Indicates if the Exception record contains payments",
     "FieldType": "YesOrNo",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "ID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "HintText": "The case reference number received in the envelope",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/cmc/data/sheets/CaseTypeTab.json
+++ b/definitions/cmc/data/sheets/CaseTypeTab.json
@@ -98,7 +98,7 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "envelopeCaseReference",
     "TabFieldDisplayOrder": 7
   },
   {
@@ -108,8 +108,18 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "containsPayments",
+    "CaseFieldID": "attachToCaseReference",
     "TabFieldDisplayOrder": 8
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "containsPayments",
+    "TabFieldDisplayOrder": 9
   },
   {
     "LiveFrom": "01/01/2018",

--- a/definitions/cmc/data/sheets/ChangeHistory.json
+++ b/definitions/cmc/data/sheets/ChangeHistory.json
@@ -135,5 +135,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "15/10/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "0.2.18",
+    "Description of Changes": "Add envelope case reference received for supplementary evidence",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "30/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/cmc/data/sheets/SearchResultFields.json
+++ b/definitions/cmc/data/sheets/SearchResultFields.json
@@ -23,8 +23,15 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "CMC_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope case reference",
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Claim reference",
-    "DisplayOrder": 4
+    "DisplayOrder": 5
   }
 ]

--- a/definitions/cmc/data/sheets/WorkBasketResultFields.json
+++ b/definitions/cmc/data/sheets/WorkBasketResultFields.json
@@ -23,22 +23,29 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "CMC_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope case reference",
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Claim reference",
-    "DisplayOrder": 4
+    "DisplayOrder": 5
   },
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "CMC_ExceptionRecord",
     "CaseFieldID": "poBox",
     "Label": "POBox",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "CMC_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-831

### Change description ###
- Added new field `envelopeCaseReference` to Exception Record case fields, which will be displayed on Exception Record.
- Added `envelopeCaseReference` to Workbasket results and Search Results.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
