### PR TITLE
Add envelope case reference to SSCS exception record

### DIFF
--- a/definitions/sscs/data/sheets/AuthorisationCaseField.json
+++ b/definitions/sscs/data/sheets/AuthorisationCaseField.json
@@ -112,6 +112,13 @@
     "CRUD": "CRUD"
   },
   {
+    "LiveFrom": "07/10/2019",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "UserRole": "caseworker-sscs",
+    "CRUD": "CRUD"
+  },
+  {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "envelopeLabel",
@@ -208,6 +215,13 @@
     "CaseFieldID": "formType",
     "UserRole": "caseworker-sscs-clerk",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "22/08/2019",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "UserRole": "caseworker-sscs-clerk",
+    "CRUD": "R"
   },
   {
     "LiveFrom": "01/01/2018",
@@ -367,6 +381,13 @@
     "LiveFrom": "07/10/2019",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "containsPayments",
+    "UserRole": "caseworker-sscs-bulkscan",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "07/10/2019",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
     "UserRole": "caseworker-sscs-bulkscan",
     "CRUD": "R"
   }

--- a/definitions/sscs/data/sheets/CaseEventToFields.json
+++ b/definitions/sscs/data/sheets/CaseEventToFields.json
@@ -101,6 +101,17 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseEventID": "createException",
+    "CaseFieldID": "envelopeCaseReference",
+    "PageFieldDisplayOrder": 10,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondance",
+    "PageColumnNumber": 1
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
     "CaseFieldID": "attachToCaseReference",
     "PageFieldDisplayOrder": 1,

--- a/definitions/sscs/data/sheets/CaseField.json
+++ b/definitions/sscs/data/sheets/CaseField.json
@@ -161,5 +161,14 @@
     "HintText": "Indicates if the Exception record contains payments",
     "FieldType": "YesOrNo",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "ID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "HintText": "The case reference number received in the envelope",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/sscs/data/sheets/CaseTypeTab.json
+++ b/definitions/sscs/data/sheets/CaseTypeTab.json
@@ -108,7 +108,7 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "envelopeCaseReference",
     "TabFieldDisplayOrder": 8
   },
   {
@@ -118,8 +118,18 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "containsPayments",
+    "CaseFieldID": "attachToCaseReference",
     "TabFieldDisplayOrder": 9
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "SSCS_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "containsPayments",
+    "TabFieldDisplayOrder": 10
   },
   {
     "LiveFrom": "01/01/2018",

--- a/definitions/sscs/data/sheets/ChangeHistory.json
+++ b/definitions/sscs/data/sheets/ChangeHistory.json
@@ -145,5 +145,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "16/10/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "1.0.24",
+    "Description of Changes": "Add envelope case reference received for supplementary evidence",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "30/10/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/sscs/data/sheets/SearchResultFields.json
+++ b/definitions/sscs/data/sheets/SearchResultFields.json
@@ -23,15 +23,22 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "DisplayOrder": 6
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Existing Case Reference",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   },
   {
     "LiveFrom": "22/08/2019",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 7
+    "DisplayOrder": 8
   }
 ]

--- a/definitions/sscs/data/sheets/WorkBasketResultFields.json
+++ b/definitions/sscs/data/sheets/WorkBasketResultFields.json
@@ -30,22 +30,29 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
+    "CaseFieldID": "envelopeCaseReference",
+    "Label": "Envelope Case Reference",
+    "DisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Existing Case Reference",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "poBox",
     "Label": "POBox",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "SSCS_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 7
+    "DisplayOrder": 8
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-831

### Change description ###
- Added new field `envelopeCaseReference` to Exception Record case fields, which will be displayed on Exception Record.
- Added `envelopeCaseReference` to Workbasket results and Search Results.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
