### PR TITLE
Fix the resulting state for createNewCase event

### DIFF
--- a/definitions/probate/data/sheets/CaseEvent.json
+++ b/definitions/probate/data/sheets/CaseEvent.json
@@ -32,7 +32,7 @@
     "Description": "Create a new case from exception",
     "DisplayOrder": 3,
     "PreConditionState(s)": "ScannedRecordReceived",
-    "PostConditionState": "ScannedRecordReceived",
+    "PostConditionState": "ScannedRecordCaseCreated",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_BULK_SCAN_ORCHESTRATOR_URL}/callback/create-new-case",
     "RetriesTimeoutURLAboutToSubmitEvent": 30,
     "SecurityClassification": "Public",

--- a/definitions/probate/data/sheets/ChangeHistory.json
+++ b/definitions/probate/data/sheets/ChangeHistory.json
@@ -159,5 +159,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "04/11/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "0.24",
+    "Description of Changes": "Fixed the final state for createNewCase event",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "17/11/2019",
+    "Created By": "Leszek Gonczar"
   }
 ]


### PR DESCRIPTION
### Change description ###

Fix the resulting state for createNewCase event. It used to be `ScannedRecordReceived`, which is incorrect.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
