### PR TITLE
Update Divorce Exception Record definition to apply phase 2 changes

### DIFF
--- a/definitions/divorce/data/sheets/AuthorisationCaseEvent.json
+++ b/definitions/divorce/data/sheets/AuthorisationCaseEvent.json
@@ -89,5 +89,26 @@
     "CaseEventID": "updateManually",
     "UserRole": "caseworker-divorce-bulkscan",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseEventID": "createNewCase",
+    "UserRole": "caseworker-divorce-bulkscan",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseEventID": "createNewCase",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseEventID": "createNewCase",
+    "UserRole": "caseworker-divorce-systemupdate",
+    "CRUD": "CRUD"
   }
 ]

--- a/definitions/divorce/data/sheets/AuthorisationCaseField.json
+++ b/definitions/divorce/data/sheets/AuthorisationCaseField.json
@@ -390,5 +390,47 @@
     "CaseFieldID": "awaitingPaymentDCNProcessing",
     "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "paymentHistory",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "paymentHistory",
+    "UserRole": "caseworker-divorce-bulkscan",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "paymentHistory",
+    "UserRole": "caseworker-divorce-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "UserRole": "caseworker-divorce-bulkscan",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "UserRole": "caseworker-divorce-systemupdate",
+    "CRUD": "CRUD"
   }
 ]

--- a/definitions/divorce/data/sheets/CaseEvent.json
+++ b/definitions/divorce/data/sheets/CaseEvent.json
@@ -25,6 +25,19 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "ID": "createNewCase",
+    "Name": "Create new case from exception",
+    "Description": "Create a new case from exception",
+    "DisplayOrder": 3,
+    "PreConditionState(s)": "ScannedRecordReceived",
+    "PostConditionState": "ScannedRecordCaseCreated",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_BULK_SCAN_ORCHESTRATOR_URL}/callback/create-new-case",
+    "RetriesTimeoutURLAboutToSubmitEvent": 30,
+    "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "ID": "rejectRecord",
     "Name": "Reject record",
     "Description": "Reject record",

--- a/definitions/divorce/data/sheets/CaseEventToFields.json
+++ b/definitions/divorce/data/sheets/CaseEventToFields.json
@@ -215,6 +215,28 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseEventID": "createNewCase",
+    "CaseFieldID": "scannedDocuments",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondence",
+    "PageDisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseEventID": "createNewCase",
+    "CaseFieldID": "scanOCRData",
+    "PageFieldDisplayOrder": 2,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondence",
+    "PageDisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseEventID": "rejectRecord",
     "CaseFieldID": "scanOCRData",
     "PageFieldDisplayOrder": 1,
@@ -250,7 +272,7 @@
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseEventID": "updateManually",
     "CaseFieldID": "scanOCRData",
-    "PageFieldDisplayOrder": 1,
+    "PageFieldDisplayOrder": 2,
     "DisplayContext": "READONLY",
     "PageID": 1,
     "PageLabel": "Corespondence",

--- a/definitions/divorce/data/sheets/CaseField.json
+++ b/definitions/divorce/data/sheets/CaseField.json
@@ -79,6 +79,15 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "ID": "caseReference",
+    "Label": "Case Reference",
+    "HintText": "Reference number of the new case created from exception record",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "ID": "caseHistory",
     "Label": "Case History",
     "FieldType": "CaseHistoryViewer",
@@ -135,6 +144,14 @@
     "Label": "Contains Payments",
     "HintText": "Indicates if the Exception record contains payments",
     "FieldType": "YesOrNo",
+    "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "ID": "paymentHistory",
+    "Label": "Payment history",
+    "FieldType": "CasePaymentHistoryViewer",
     "SecurityClassification": "PUBLIC"
   },
   {

--- a/definitions/divorce/data/sheets/CaseTypeTab.json
+++ b/definitions/divorce/data/sheets/CaseTypeTab.json
@@ -98,7 +98,7 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "caseReference",
     "TabFieldDisplayOrder": 7
   },
   {
@@ -108,8 +108,18 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "containsPayments",
+    "CaseFieldID": "attachToCaseReference",
     "TabFieldDisplayOrder": 8
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "containsPayments",
+    "TabFieldDisplayOrder": 9
   },
   {
     "LiveFrom": "01/01/2017",
@@ -142,5 +152,15 @@
     "CaseFieldID": "scanOCRData",
     "TabFieldDisplayOrder": 2,
     "FieldShowCondition": " "
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "payments",
+    "TabLabel": "Payments",
+    "TabDisplayOrder": 6,
+    "CaseFieldID": "paymentHistory",
+    "TabFieldDisplayOrder": 1
   }
 ]

--- a/definitions/divorce/data/sheets/ChangeHistory.json
+++ b/definitions/divorce/data/sheets/ChangeHistory.json
@@ -129,5 +129,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "04/11/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "0.20",
+    "Description of Changes": "Add createNewCase event and the required fields",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "25/11/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/divorce/data/sheets/SearchInputFields.json
+++ b/definitions/divorce/data/sheets/SearchInputFields.json
@@ -30,22 +30,36 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "Label": "New Case Reference",
+    "DisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
+  },
+  {
+    "LiveFrom": "01/08/2019",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "formType",
+    "Label": "Form Type",
+    "DisplayOrder": 8
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "containsPayments",
     "Label": "Contains Payments",
-    "DisplayOrder": 7
+    "DisplayOrder": 9
   }
 ]

--- a/definitions/divorce/data/sheets/SearchResultFields.json
+++ b/definitions/divorce/data/sheets/SearchResultFields.json
@@ -16,8 +16,22 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "Label": "New Case Reference",
+    "DisplayOrder": 3
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 3
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "formType",
+    "Label": "Form Type",
+    "DisplayOrder": 5
   }
 ]

--- a/definitions/divorce/data/sheets/WorkBasketInputFields.json
+++ b/definitions/divorce/data/sheets/WorkBasketInputFields.json
@@ -2,8 +2,15 @@
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "formType",
+    "Label": "Form Type",
+    "DisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/08/2019",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "containsPayments",
     "Label": "Contains Payments",
-    "DisplayOrder": 1
+    "DisplayOrder": 2
   }
 ]

--- a/definitions/divorce/data/sheets/WorkBasketResultFields.json
+++ b/definitions/divorce/data/sheets/WorkBasketResultFields.json
@@ -23,22 +23,36 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "caseReference",
+    "Label": "New Case Reference",
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
     "Label": "Attach to Case Reference",
-    "DisplayOrder": 4
+    "DisplayOrder": 5
   },
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "poBox",
     "Label": "PO Box",
-    "DisplayOrder": 5
+    "DisplayOrder": 6
   },
   {
     "LiveFrom": "01/08/2019",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "journeyClassification",
     "Label": "Journey Classification",
-    "DisplayOrder": 6
+    "DisplayOrder": 7
+  },
+  {
+    "LiveFrom": "01/08/2019",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "formType",
+    "Label": "Form Type",
+    "DisplayOrder": 8
   }
 ]

--- a/definitions/probate/data/sheets/SearchInputFields.json
+++ b/definitions/probate/data/sheets/SearchInputFields.json
@@ -10,7 +10,7 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "openingDate",
-    "Label": "Openning Date",
+    "Label": "Opening Date",
     "DisplayOrder": 2
   },
   {


### PR DESCRIPTION
### Change description ###
Updated Divorce exception record for phase 2
- add `createNewCase` event
- add `caseReference` field (for the new case reference )
- add `paymentHistory` field
- add `payments` tab 
- add `formType` field to search and workbasket tabs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
