### PR TITLE
Update CMC exception record definition with phase 2 changes

### DIFF
--- a/definitions/cmc/data/sheets/CaseEvent.json
+++ b/definitions/cmc/data/sheets/CaseEvent.json
@@ -56,5 +56,18 @@
     "SecurityClassification": "Public",
     "ShowEventNotes": "N",
     "CanSaveDraft": "N"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "ID": "createNewCase",
+    "Name": "Create new case from exception",
+    "Description": "Create a new case from exception",
+    "DisplayOrder": 6,
+    "PreConditionState(s)": "ScannedRecordReceived",
+    "PostConditionState": "ScannedRecordCaseCreated",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_BULK_SCAN_ORCHESTRATOR_URL}/callback/create-new-case",
+    "RetriesTimeoutURLAboutToSubmitEvent": 30,
+    "SecurityClassification": "Public"
   }
 ]

--- a/definitions/cmc/data/sheets/CaseEventToFields.json
+++ b/definitions/cmc/data/sheets/CaseEventToFields.json
@@ -233,5 +233,27 @@
     "PageID": 1,
     "PageLabel": "Corespondence",
     "PageDisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "CaseEventID": "createNewCase",
+    "CaseFieldID": "scannedDocuments",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondence",
+    "PageDisplayOrder": 1
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "CaseEventID": "createNewCase",
+    "CaseFieldID": "scanOCRData",
+    "PageFieldDisplayOrder": 2,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Corespondence",
+    "PageDisplayOrder": 1
   }
 ]

--- a/definitions/cmc/data/sheets/CaseField.json
+++ b/definitions/cmc/data/sheets/CaseField.json
@@ -191,5 +191,22 @@
     "HintText": "Indicates if the envelope legacy case reference field should be displayed",
     "FieldType": "YesOrNo",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "ID": "caseReference",
+    "Label": "Case Reference",
+    "HintText": "Reference number of the new case created from exception record",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "ID": "paymentHistory",
+    "Label": "Payment history",
+    "FieldType": "CasePaymentHistoryViewer",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/cmc/data/sheets/CaseTypeTab.json
+++ b/definitions/cmc/data/sheets/CaseTypeTab.json
@@ -98,7 +98,7 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "caseReference",
     "TabFieldDisplayOrder": 7
   },
   {
@@ -108,8 +108,18 @@
     "TabID": "envelope",
     "TabLabel": "Envelope",
     "TabDisplayOrder": 3,
-    "CaseFieldID": "containsPayments",
+    "CaseFieldID": "attachToCaseReference",
     "TabFieldDisplayOrder": 8
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "envelope",
+    "TabLabel": "Envelope",
+    "TabDisplayOrder": 3,
+    "CaseFieldID": "containsPayments",
+    "TabFieldDisplayOrder": 9
   },
   {
     "LiveFrom": "01/01/2018",
@@ -142,5 +152,15 @@
     "CaseFieldID": "scanOCRData",
     "TabFieldDisplayOrder": 2,
     "FieldShowCondition": " "
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "FINREM_ExceptionRecord",
+    "Channel": "CaseWorker",
+    "TabID": "payments",
+    "TabLabel": "Payments",
+    "TabDisplayOrder": 6,
+    "CaseFieldID": "paymentHistory",
+    "TabFieldDisplayOrder": 1
   }
 ]

--- a/definitions/cmc/data/sheets/ChangeHistory.json
+++ b/definitions/cmc/data/sheets/ChangeHistory.json
@@ -149,5 +149,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "04/11/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "0.2.20",
+    "Description of Changes": "Add createNewCase event and the required fields. Authorisation for createNewCase event, caseReference and paymentsHistory fields and filter by new case reference will be added when service starts using phase 2.",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "28/11/2019",
+    "Created By": "Aliveni Choppa"
   }
 ]

--- a/definitions/cmc/data/sheets/State.json
+++ b/definitions/cmc/data/sheets/State.json
@@ -21,7 +21,7 @@
     "ID": "ScannedRecordRejected",
     "Name": "Rejected",
     "Description": "The scanned record has been rejected",
-    "DisplayOrder": 4
+    "DisplayOrder": 3
   },
   {
     "LiveFrom": "01/01/2018",
@@ -29,6 +29,14 @@
     "ID": "ScannedRecordManuallyHandled",
     "Name": "Manually handled",
     "Description": "The scanned record has been handled byCW manually",
+    "DisplayOrder": 4
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "CMC_ExceptionRecord",
+    "ID": "ScannedRecordCaseCreated",
+    "Name": "Case created",
+    "Description": "A new case is created from scanned record",
     "DisplayOrder": 5
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-908

### Change description ###
Updated CMC exception record for phase 2

- add `createNewCase` event
- add `caseReference` field (for the new case reference )
- add `paymentHistory` field
- add `payments` tab

**When onboarding the service to phase 2** 
- Add authorisation for `createNewCase` event, `caseReference` and `paymentHistory` fields.
- Add search filter on `formType`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
