### PR TITLE
Fix the name of the attachScannedDocsWithOcr event

### DIFF
--- a/definitions/bulkscan/data/sheets/CaseEvent.json
+++ b/definitions/bulkscan/data/sheets/CaseEvent.json
@@ -39,7 +39,7 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "Bulk_Scanned",
     "ID": "attachScannedDocsWithOcr",
-    "Name": "Attach scanned docs with OCR data",
+    "Name": "Attach docs with OCR data",
     "Description": "Attach scanned docs with OCR data",
     "DisplayOrder": 4,
     "PreConditionState(s)": "*",


### PR DESCRIPTION
### Change description ###

Fix the name of the attachScannedDocsWithOcr event - was too long for CCD to accept the definition.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
