### PR TITLE
Change the label of 'Payments' tab to 'Payment History' for Divorce

### DIFF
--- a/definitions/divorce/data/sheets/CaseTypeTab.json
+++ b/definitions/divorce/data/sheets/CaseTypeTab.json
@@ -158,7 +158,7 @@
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "Channel": "CaseWorker",
     "TabID": "payments",
-    "TabLabel": "Payments",
+    "TabLabel": "Payment History",
     "TabDisplayOrder": 6,
     "CaseFieldID": "paymentHistory",
     "TabFieldDisplayOrder": 1

--- a/definitions/divorce/data/sheets/ChangeHistory.json
+++ b/definitions/divorce/data/sheets/ChangeHistory.json
@@ -150,5 +150,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "19/12/2019",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "0.23",
+    "Description of Changes": "Change 'Payments' tab label to 'Payment History'",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "30/12/2019",
+    "Created By": "Leszek Gonczar"
   }
 ]


### PR DESCRIPTION
### Change description ###

Change the label of 'Payments' tab to 'Payment History' for Divorce. The change was requested for Probate and this PR is there for consistency.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
