### PR TITLE
Change the label of 'Payments' tab to 'Payment History' for BulkScan exception.

### DIFF
--- a/definitions/bulkscan-exception/data/sheets/CaseTypeTab.json
+++ b/definitions/bulkscan-exception/data/sheets/CaseTypeTab.json
@@ -167,7 +167,7 @@
     "CaseTypeID": "BULKSCAN_ExceptionRecord",
     "Channel": "CaseWorker",
     "TabID": "payments",
-    "TabLabel": "Payments",
+    "TabLabel": "Payment History",
     "TabDisplayOrder": 6,
     "CaseFieldID": "paymentHistory",
     "TabFieldDisplayOrder": 1

--- a/definitions/bulkscan-exception/data/sheets/ChangeHistory.json
+++ b/definitions/bulkscan-exception/data/sheets/ChangeHistory.json
@@ -243,5 +243,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "19/12/2019",
     "Created By": "Mustafa Dayican"
+  },
+  {
+    "Version Number": "0.36",
+    "Description of Changes": "Change 'Payments' tab label to 'Payment History'",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "30/12/2019",
+    "Created By": "Leszek Gonczar"
   }
 ]


### PR DESCRIPTION
### Change description ###

Change the label of 'Payments' tab to 'Payment History' for BulkScan exception. The change was requested for Probate and this PR is there for consistency.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
