### PR TITLE
Configure fields for extendCaveatCase event in PROBATE_ExceptionRecord

### DIFF
--- a/definitions/probate/data/sheets/CaseEventToFields.json
+++ b/definitions/probate/data/sheets/CaseEventToFields.json
@@ -213,6 +213,76 @@
     "PageColumnNumber": 1
   },
   {
+    "LiveFrom": "03/04/2020",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseEventID": "extendCaveatCase",
+    "CaseFieldID": "envelopeCaseReference",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "READONLY",
+    "PageID": 1,
+    "PageLabel": "Correspondence",
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "showEnvelopeCaseReference=\"Yes\""
+  },
+  {
+    "LiveFrom": "03/04/2020",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseEventID": "extendCaveatCase",
+    "CaseFieldID": "envelopeLegacyCaseReference",
+    "PageFieldDisplayOrder": 2,
+    "DisplayContext": "READONLY",
+    "PageID": 1,
+    "PageLabel": "Correspondence",
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "showEnvelopeLegacyCaseReference=\"Yes\""
+  },
+  {
+    "LiveFrom": "03/04/2020",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseEventID": "extendCaveatCase",
+    "CaseFieldID": "showEnvelopeCaseReference",
+    "PageFieldDisplayOrder": 3,
+    "DisplayContext": "READONLY",
+    "PageID": 1,
+    "PageLabel": "Correspondence",
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "envelopeCaseReference=\"{NeverShowThisFieldOnUI}\""
+  },
+  {
+    "LiveFrom": "03/04/2020",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseEventID": "extendCaveatCase",
+    "CaseFieldID": "showEnvelopeLegacyCaseReference",
+    "PageFieldDisplayOrder": 4,
+    "DisplayContext": "READONLY",
+    "PageID": 1,
+    "PageLabel": "Correspondence",
+    "PageColumnNumber": 1,
+    "FieldShowCondition": "envelopeLegacyCaseReference=\"{NeverShowThisFieldOnUI}\""
+  },
+  {
+    "LiveFrom": "03/04/2020",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseEventID": "extendCaveatCase",
+    "CaseFieldID": "attachToCaseReference",
+    "PageFieldDisplayOrder": 5,
+    "DisplayContext": "MANDATORY",
+    "PageID": 1,
+    "PageLabel": "Correspondence",
+    "PageColumnNumber": 1
+  },
+  {
+    "LiveFrom": "03/04/2020",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseEventID": "extendCaveatCase",
+    "CaseFieldID": "scannedDocuments",
+    "PageFieldDisplayOrder": 6,
+    "DisplayContext": "OPTIONAL",
+    "PageID": 1,
+    "PageLabel": "Correspondence",
+    "PageColumnNumber": 1
+  },
+  {
     "LiveFrom": "30/09/2019",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseEventID": "createNewCase",

--- a/definitions/probate/data/sheets/ChangeHistory.json
+++ b/definitions/probate/data/sheets/ChangeHistory.json
@@ -194,5 +194,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "31/03/2020",
     "Created By": "Mustafa Dayican"
+  },
+  {
+    "Version Number": "0.29",
+    "Description of Changes": "Connect extendCaveatCase event with appropriate fields",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "03/04/2020",
+    "Created By": "Leszek Gonczar"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1106

### Change description ###

Configure fields for extendCaveatCase event in PROBATE_ExceptionRecord

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
