### PR TITLE
DIVORCE - Add searchCaseReference field to attach the Exception Record

### DIFF
--- a/definitions/divorce/data/sheets/AuthorisationCaseField.json
+++ b/definitions/divorce/data/sheets/AuthorisationCaseField.json
@@ -65,6 +65,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "searchCaseReference",
+    "UserRole": "caseworker-divorce-courtadmin_beta",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "caseHistory",
     "UserRole": "caseworker-divorce-courtadmin_beta",
     "CRUD": "CRUD"
@@ -185,6 +192,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
+    "UserRole": "caseworker-divorce-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "searchCaseReference",
     "UserRole": "caseworker-divorce-systemupdate",
     "CRUD": "CRUD"
   },
@@ -318,6 +332,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
+    "UserRole": "caseworker-divorce-bulkscan",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "CaseFieldID": "searchCaseReference",
     "UserRole": "caseworker-divorce-bulkscan",
     "CRUD": "CRUD"
   },

--- a/definitions/divorce/data/sheets/CaseEventToFields.json
+++ b/definitions/divorce/data/sheets/CaseEventToFields.json
@@ -194,7 +194,7 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "DIVORCE_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "searchCaseReference",
     "PageFieldDisplayOrder": 5,
     "DisplayContext": "MANDATORY",
     "PageID": 1,

--- a/definitions/divorce/data/sheets/CaseField.json
+++ b/definitions/divorce/data/sheets/CaseField.json
@@ -198,5 +198,14 @@
     "HintText": "Surname",
     "FieldType": "Text",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "DIVORCE_ExceptionRecord",
+    "ID": "searchCaseReference",
+    "Label": "Case Reference",
+    "HintText": "The case reference to attach the envelope to",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/divorce/data/sheets/ChangeHistory.json
+++ b/definitions/divorce/data/sheets/ChangeHistory.json
@@ -157,5 +157,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "30/12/2019",
     "Created By": "Leszek Gonczar"
+  },
+  {
+    "Version Number": "0.24",
+    "Description of Changes": "Add searchCaseReference field to attachToExistingCase event",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "18/06/2020",
+    "Created By": "Aliveni Choppa"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1275


### Change description ###
- Add `searchCaseReference` field to DIVORCE_ExceptionRecord CCD definition.
- Use `searchCaseReference` field to attach the exception record to

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
