### PR TITLE
PROBATE - Add searchCaseReference field to attach the Exception Record

### DIFF
--- a/definitions/probate/data/sheets/AuthorisationCaseField.json
+++ b/definitions/probate/data/sheets/AuthorisationCaseField.json
@@ -65,6 +65,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "searchCaseReference",
+    "UserRole": "caseworker-probate-systemupdate",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "caseReference",
     "UserRole": "caseworker-probate-systemupdate",
     "CRUD": "CRUD"
@@ -198,6 +205,13 @@
   {
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "searchCaseReference",
+    "UserRole": "caseworker-probate-issuer",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "caseReference",
     "UserRole": "caseworker-probate-issuer",
     "CRUD": "CRUD"
@@ -318,6 +332,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
+    "UserRole": "caseworker-probate-caseadmin",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "searchCaseReference",
     "UserRole": "caseworker-probate-caseadmin",
     "CRUD": "CRUD"
   },
@@ -465,6 +486,13 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseFieldID": "attachToCaseReference",
+    "UserRole": "caseworker-probate-bulkscan",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "CaseFieldID": "searchCaseReference",
     "UserRole": "caseworker-probate-bulkscan",
     "CRUD": "CRUD"
   },

--- a/definitions/probate/data/sheets/CaseEventToFields.json
+++ b/definitions/probate/data/sheets/CaseEventToFields.json
@@ -194,7 +194,7 @@
     "LiveFrom": "01/01/2018",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseEventID": "attachToExistingCase",
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "searchCaseReference",
     "PageFieldDisplayOrder": 5,
     "DisplayContext": "MANDATORY",
     "PageID": 1,

--- a/definitions/probate/data/sheets/CaseField.json
+++ b/definitions/probate/data/sheets/CaseField.json
@@ -207,5 +207,14 @@
     "HintText": "Reclassify to supplementary evidence with OCR",
     "FieldType": "Label",
     "SecurityClassification": "PUBLIC"
+  },
+  {
+    "LiveFrom": "01/01/2018",
+    "CaseTypeID": "PROBATE_ExceptionRecord",
+    "ID": "searchCaseReference",
+    "Label": "Case Reference",
+    "HintText": "The case reference to attach the envelope to",
+    "FieldType": "Text",
+    "SecurityClassification": "PUBLIC"
   }
 ]

--- a/definitions/probate/data/sheets/ChangeHistory.json
+++ b/definitions/probate/data/sheets/ChangeHistory.json
@@ -208,5 +208,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "06/04/2020",
     "Created By": "Leszek Gonczar"
+  },
+  {
+    "Version Number": "0.31",
+    "Description of Changes": "Add searchCaseReference field to attachToExistingCase event",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "18/06/2020",
+    "Created By": "Aliveni Choppa"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1275


### Change description ###
- Add `searchCaseReference` field to PROBATE_ExceptionRecord CCD definition.
- Use `searchCaseReference` field to attach the exception record to

The CCD definition will be uploaded to the demo environment after merging hmcts/bulk-scan-orchestrator#1015

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
