### PR TITLE
Replace attachToCaseReference with searchCaseReference field

### DIFF
--- a/definitions/probate/data/sheets/CaseEventToFields.json
+++ b/definitions/probate/data/sheets/CaseEventToFields.json
@@ -264,7 +264,7 @@
     "LiveFrom": "03/04/2020",
     "CaseTypeID": "PROBATE_ExceptionRecord",
     "CaseEventID": "extendCaveatCase",
-    "CaseFieldID": "attachToCaseReference",
+    "CaseFieldID": "searchCaseReference",
     "PageFieldDisplayOrder": 5,
     "DisplayContext": "MANDATORY",
     "PageID": 1,

--- a/definitions/probate/data/sheets/ChangeHistory.json
+++ b/definitions/probate/data/sheets/ChangeHistory.json
@@ -215,5 +215,12 @@
     "Uses CCD Template": "N/A",
     "LiveFrom": "18/06/2020",
     "Created By": "Aliveni Choppa"
+  },
+  {
+    "Version Number": "0.32",
+    "Description of Changes": "Map target case reference to searchCaseReference field for extendCaveatCase event",
+    "Uses CCD Template": "N/A",
+    "LiveFrom": "09/07/2020",
+    "Created By": "Aliveni Choppa"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1275


### Change description ###
Replace `attachToCaseReference` field with `searchCaseReference` field for `extendCaveatCase` event in PROBATE_ExceptionRecord.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
